### PR TITLE
Add galaxy role for installing kafka prometheus exporter onto the ami

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -6,5 +6,6 @@
     - aws-nvme-device-files
     - mounted-volume
     - kafka
+    - kafka-prometheus-exporter
     - logrotate
     - prometheus-node-exporter

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -7,7 +7,7 @@ roles:
 
   - src: https://github.com/companieshouse/ansible-role-kafka-prometheus-exporter
     name: kafka-prometheus-exporter
-    version: kafka-3.1.0-0.1.0
+    version: kafka-3.1.0
 
   - src: https://github.com/companieshouse/ansible-role-logrotate
     name: logrotate

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -5,6 +5,10 @@ roles:
     name: aws-nvme-device-files
     version: 1.1.0
 
+  - src: https://github.com/companieshouse/ansible-role-kafka-prometheus-exporter
+    name: kafka-prometheus-exporter
+    version: kafka-3.1.0-0.1.0
+
   - src: https://github.com/companieshouse/ansible-role-logrotate
     name: logrotate
     version: 1.6.1


### PR DESCRIPTION
Add `Kafka Prometheus Exporter` galaxy role to the `Kafka-AMI` Build.

Used for collecting `Kafka` metrics which can be used for monitoring things like lag etc.

Resolves: DVOP-2075